### PR TITLE
Make languages selector nicer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Protocols.Lino/issues/92
-Your prepared branch: issue-92-70482ba1
-Your prepared working directory: /tmp/gh-issue-solver-1758948163159
-Your forked repository: konard/Protocols.Lino
-Original repository (upstream): linksplatform/Protocols.Lino
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/linksplatform/Protocols.Lino/issues/92
+Your prepared branch: issue-92-70482ba1
+Your prepared working directory: /tmp/gh-issue-solver-1758948163159
+Your forked repository: konard/Protocols.Lino
+Original repository (upstream): linksplatform/Protocols.Lino
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Protocols.Lino](https://github.com/linksplatform/Protocols.Lino) ([русская версия](README.ru.md))
+# [Protocols.Lino](https://github.com/linksplatform/Protocols.Lino) (languages: en • [ru](README.ru.md))
 
 
 | [![Actions Status](https://github.com/linksplatform/Protocols.Lino/workflows/js/badge.svg)](https://github.com/linksplatform/Protocols.Lino/actions?workflow=js) | [![npm Version and Downloads count](https://img.shields.io/npm/v/@linksplatform/protocols-lino?label=npm&style=flat)](https://www.npmjs.com/package/@linksplatform/protocols-lino) | **[JavaScript](js/README.md)** |

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-# [Protocols.Lino](https://github.com/linksplatform/Protocols.Lino) ([english version](README.md))
+# [Protocols.Lino](https://github.com/linksplatform/Protocols.Lino) (languages: [en](README.md) • ru)
 
 | [![Состояние Actions](https://github.com/linksplatform/Protocols.Lino/workflows/js/badge.svg)](https://github.com/linksplatform/Protocols.Lino/actions?workflow=js) | [![Версия npm пакета и количество загрузок](https://img.shields.io/npm/v/@linksplatform/protocols-lino?label=npm&style=flat)](https://www.npmjs.com/package/@linksplatform/protocols-lino) | **[JavaScript](js/README.ru.md)** |
 |:-|-:|:-|


### PR DESCRIPTION
## Summary

Updated the language selector format in README files to make it more consistent and visually appealing.

### Changes

- Changed language selector format from descriptive text to unified format: `(languages: current • [other](link))`
- Current language is displayed as plain text (not a link)
- Other languages are displayed as clickable links
- Uses bullet separator (•) between languages

### Example

**Before:**
- English README: `([русская версия](README.ru.md))`
- Russian README: `([english version](README.md))`

**After:**
- English README: `(languages: en • [ru](README.ru.md))`
- Russian README: `(languages: [en](README.md) • ru)`

### Files Modified

- `README.md` - Updated language selector in English version
- `README.ru.md` - Updated language selector in Russian version

Fixes #92

---
🤖 Generated with [Claude Code](https://claude.ai/code)