### PR TITLE
Fix C# workflow YAML syntax error preventing 0.7.0 publication

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -155,8 +155,8 @@ jobs:
           RELEASE_NAME="[C#] $PACKAGE_VERSION"
           RELEASE_BODY="$PACKAGE_URL
 
-$PACKAGE_RELEASE_NOTES"
-          
+          $PACKAGE_RELEASE_NOTES"
+
           ./publish-release.sh "$TAG" "$RELEASE_NAME" "$RELEASE_BODY"
   generatePdfWithCode:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Protocols.Lino/issues/109
+Your prepared branch: issue-109-d76b5c33
+Your prepared working directory: /tmp/gh-issue-solver-1759583256530
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Protocols.Lino/issues/109
-Your prepared branch: issue-109-d76b5c33
-Your prepared working directory: /tmp/gh-issue-solver-1759583256530
-
-Proceed.


### PR DESCRIPTION
## 🔍 Root Cause Analysis

The C# version 0.7.0 was not published to NuGet because the GitHub Actions workflow file (`.github/workflows/csharp.yml`) had a **YAML syntax error** that prevented the workflow from executing.

### The Issue

**Line 158** in `.github/workflows/csharp.yml` had incorrect indentation:
- Expected: 10 spaces (to match the `run: |` literal block scalar)
- Actual: 0 spaces

```yaml
# Before (broken):
RELEASE_BODY="$PACKAGE_URL

$PACKAGE_RELEASE_NOTES"    # ❌ Line 158 has 0 spaces

# After (fixed):
RELEASE_BODY="$PACKAGE_URL

          $PACKAGE_RELEASE_NOTES"    # ✅ Line 158 now has 10 spaces
```

### Impact Timeline

- **Since**: Commit [0f80a9b](https://github.com/linksplatform/Protocols.Lino/commit/0f80a9b) (October 2, 2025)
- **Affected**: All C# workflow runs from Oct 2 onwards
- **Result**: 
  - ❌ All C# workflow runs had **0 jobs executed** (workflow file couldn't be parsed)
  - ❌ Version 0.7.0 was never published to NuGet
  - ❌ No C# releases or documentation updates
  - ✅ JavaScript and Rust workflows continued working (0.7.0 published successfully)

### Evidence

```bash
# All C# workflow runs since Oct 2 had 0 jobs:
$ gh api repos/linksplatform/Protocols.Lino/actions/runs/18224649976/jobs
{"jobs":[],"total_count":0}

# YAML validation failed:
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/csharp.yml'))"
yaml.scanner.ScannerError: could not find expected ':'
  in ".github/workflows/csharp.yml", line 161, column 22
```

### Current Status

| Package | Version 0.7.0 Status | Released Date |
|---------|---------------------|---------------|
| **JavaScript** | ✅ Published to NPM | Oct 3, 2025 |
| **Rust** | ✅ Published to Crates.io | Oct 3, 2025 |
| **C#** | ❌ Not published (pending this fix) | - |

## ✅ Solution

Fixed the indentation on line 158 to match the surrounding `run: |` block indentation (10 spaces).

### Verification

After the fix:
- ✅ YAML syntax is now valid
- ✅ C# workflow executed successfully on this PR (2 jobs ran)
- ✅ All tests passed

### Next Steps

Once merged to `main`:
1. The fixed workflow will trigger on the merge commit
2. It will detect the existing version 0.7.0 in the csproj file
3. It will publish version 0.7.0 to NuGet (since it doesn't exist yet)
4. It will create the GitHub release `0.7.0_csharp`

Fixes #109

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>